### PR TITLE
Add Go 'next' as a test target

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,4 +17,4 @@ jobs:
   go-test:
     uses: pl-strflt/uci/.github/workflows/go-test.yml@v0.0
     with:
-      go-versions: '["this"]'
+      go-versions: '["this", "next"]'


### PR DESCRIPTION
Tests against Go 1.21 as well as 1.20