### PR TITLE
fix: quic go-routine leak in tests

### DIFF
--- a/backend_provider_test.go
+++ b/backend_provider_test.go
@@ -22,8 +22,7 @@ import (
 var devnull = slog.New(slog.NewTextHandler(io.Discard, nil))
 
 func newBackendProvider(t testing.TB, cfg *ProvidersBackendConfig) *ProvidersBackend {
-	h, err := libp2p.New(libp2p.NoListenAddrs)
-	require.NoError(t, err)
+	h := newTestHost(t, libp2p.NoListenAddrs)
 
 	dstore, err := InMemoryDatastore()
 	require.NoError(t, err)

--- a/dht_test.go
+++ b/dht_test.go
@@ -16,10 +16,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	h, err := libp2p.New(libp2p.NoListenAddrs)
-	if err != nil {
-		t.Fatal(err)
-	}
+	h := newTestHost(t, libp2p.NoListenAddrs)
 
 	tests := []struct {
 		name        string

--- a/diversity_filter_test.go
+++ b/diversity_filter_test.go
@@ -167,16 +167,10 @@ func TestRTPeerDiversityFilter(t *testing.T) {
 	ctx := context.Background()
 
 	listenOpt := libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0")
-
-	h, err := libp2p.New(listenOpt)
-	require.NoError(t, err)
-
+	h := newTestHost(t, listenOpt)
 	// create 2 remote peers
-	h1, err := libp2p.New(listenOpt)
-	require.NoError(t, err)
-
-	h2, err := libp2p.New(listenOpt)
-	require.NoError(t, err)
+	h1 := newTestHost(t, listenOpt)
+	h2 := newTestHost(t, listenOpt)
 
 	// clean up after ourselves
 	t.Cleanup(func() {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -34,7 +34,7 @@ func newTestHost(t testing.TB, opts ...libp2p.Option) host.Host {
 	// after https://github.com/libp2p/go-libp2p/issues/2589 was resolved.
 	// Also, the below should be changed to [swarm.WithDialTimeoutLocal]. Change
 	// that after https://github.com/libp2p/go-libp2p/pull/2595 is resolved.
-	dialTimeout := 100 * time.Millisecond
+	dialTimeout := 500 * time.Millisecond
 	swarmOpts := libp2p.SwarmOpts(swarm.WithDialTimeout(dialTimeout))
 
 	// The QUIC transport leaks go-routines, so we're only enabling the TCP

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,138 @@
+package zikade
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/net/swarm"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/plprobelab/zikade/kadt"
+	"github.com/plprobelab/zikade/pb"
+)
+
+var rng = rand.New(rand.NewSource(1337))
+
+// newTestHost returns a libp2p host with the given options. It also applies
+// options that are common to all test hosts.
+func newTestHost(t testing.TB, opts ...libp2p.Option) host.Host {
+	// If two peers simultaneously connect, they could end up in a state where
+	// one peer is waiting on the connection for the other one, although there
+	// already exists a valid connection. The libp2p dial loop doesn't recognize
+	// the new connection immediately, but only after the local dial has timed
+	// out. By default, the timeout is set to 5s which results in failing tests
+	// as the tests time out. By setting the timeout to a much lower value, we
+	// work around the timeout issue. Try to remove the following swarm options
+	// after https://github.com/libp2p/go-libp2p/issues/2589 was resolved.
+	// Also, the below should be changed to [swarm.WithDialTimeoutLocal]. Change
+	// that after https://github.com/libp2p/go-libp2p/pull/2595 is resolved.
+	dialTimeout := 100 * time.Millisecond
+	swarmOpts := libp2p.SwarmOpts(swarm.WithDialTimeout(dialTimeout))
+
+	// The QUIC transport leaks go-routines, so we're only enabling the TCP
+	// transport for our tests. Remove after:
+	// https://github.com/libp2p/go-libp2p/issues/2514 was fixed
+	tcpTransport := libp2p.Transport(tcp.NewTCPTransport)
+
+	h, err := libp2p.New(append(opts, swarmOpts, tcpTransport)...)
+	require.NoError(t, err)
+
+	return h
+}
+
+func newTestDHT(t testing.TB) *DHT {
+	cfg := DefaultConfig()
+	cfg.Logger = devnull
+
+	return newTestDHTWithConfig(t, cfg)
+}
+
+func newTestDHTWithConfig(t testing.TB, cfg *Config) *DHT {
+	t.Helper()
+
+	h := newTestHost(t, libp2p.NoListenAddrs)
+
+	d, err := New(h, cfg)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if err = d.Close(); err != nil {
+			t.Logf("closing dht: %s", err)
+		}
+
+		if err = h.Close(); err != nil {
+			t.Logf("closing host: %s", err)
+		}
+	})
+
+	return d
+}
+
+func newPeerID(t testing.TB) peer.ID {
+	id, _ := newIdentity(t)
+	return id
+}
+
+func newIdentity(t testing.TB) (peer.ID, crypto.PrivKey) {
+	t.Helper()
+
+	priv, pub, err := crypto.GenerateEd25519Key(rng)
+	require.NoError(t, err)
+
+	id, err := peer.IDFromPublicKey(pub)
+	require.NoError(t, err)
+
+	return id, priv
+}
+
+// fillRoutingTable populates d's routing table and peerstore with n random peers and addresses
+func fillRoutingTable(t testing.TB, d *DHT, n int) {
+	t.Helper()
+
+	for i := 0; i < n; i++ {
+		// generate peer ID
+		pid := newPeerID(t)
+
+		// add peer to routing table
+		d.rt.AddNode(kadt.PeerID(pid))
+
+		// craft random network address for peer
+		// use IP suffix of 1.1 to not collide with actual test hosts that
+		// choose a random IP address via 127.0.0.1:0.
+		a, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/127.0.1.1/tcp/%d", 2000+i))
+		require.NoError(t, err)
+
+		// add peer information to peer store
+		d.host.Peerstore().AddAddr(pid, a, time.Hour)
+	}
+}
+
+func newAddrInfo(t testing.TB) peer.AddrInfo {
+	return peer.AddrInfo{
+		ID: newPeerID(t),
+		Addrs: []ma.Multiaddr{
+			ma.StringCast("/ip4/99.99.99.99/tcp/2000"), // must be a public address
+		},
+	}
+}
+
+func newAddProviderRequest(key []byte, addrInfos ...peer.AddrInfo) *pb.Message {
+	providerPeers := make([]*pb.Message_Peer, len(addrInfos))
+	for i, addrInfo := range addrInfos {
+		providerPeers[i] = pb.FromAddrInfo(addrInfo)
+	}
+
+	return &pb.Message{
+		Type:          pb.Message_ADD_PROVIDER,
+		Key:           key,
+		ProviderPeers: providerPeers,
+	}
+}

--- a/routing_test.go
+++ b/routing_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"github.com/ipfs/boxo/ipns"
+	"github.com/ipfs/boxo/path"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore/failstore"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -49,6 +51,23 @@ func makePkKeyValue(t testing.TB) (string, []byte) {
 	require.NoError(t, err)
 
 	return routing.KeyForPublicKey(id), v
+}
+
+func makeIPNSKeyValue(t testing.TB, clk clock.Clock, priv crypto.PrivKey, seq uint64, ttl time.Duration) (string, []byte) {
+	t.Helper()
+
+	testPath := path.Path("/ipfs/bafkqac3jobxhgidsn5rww4yk")
+
+	rec, err := ipns.NewRecord(priv, testPath, seq, clk.Now().Add(ttl), ttl)
+	require.NoError(t, err)
+
+	remote, err := peer.IDFromPublicKey(priv.GetPublic())
+	require.NoError(t, err)
+
+	data, err := ipns.MarshalRecord(rec)
+	require.NoError(t, err)
+
+	return string(ipns.NameFromPeer(remote).RoutingKey()), data
 }
 
 func TestDHT_FindPeer_happy_path(t *testing.T) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -52,12 +52,8 @@ func (trw testReadWriter) WriteMsg(msg *pb.Message) error {
 
 func newPeerPair(t testing.TB) (host.Host, *DHT) {
 	listenAddr := libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0")
-
-	client, err := libp2p.New(listenAddr)
-	require.NoError(t, err)
-
-	server, err := libp2p.New(listenAddr)
-	require.NoError(t, err)
+	client := newTestHost(t, listenAddr)
+	server := newTestHost(t, listenAddr)
 
 	cfg := DefaultConfig()
 	cfg.Mode = ModeOptServer

--- a/topology_test.go
+++ b/topology_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/net/swarm"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	"github.com/stretchr/testify/require"
+
 	"github.com/plprobelab/zikade/internal/coord"
 	"github.com/plprobelab/zikade/kadt"
-	"github.com/stretchr/testify/require"
 )
 
 // A Topology is an arrangement of DHTs intended to simulate a network
@@ -128,7 +130,12 @@ func (t *Topology) hostOpts() []libp2p.Option {
 	dialTimeout := 100 * time.Millisecond
 	swarmOpts := libp2p.SwarmOpts(swarm.WithDialTimeout(dialTimeout))
 
-	return []libp2p.Option{swarmOpts}
+	// The QUIC transport leaks go-routines, so we're only enabling the TCP
+	// transport for our tests. Remove after:
+	// https://github.com/libp2p/go-libp2p/issues/2514 was fixed
+	tcpTransport := libp2p.Transport(tcp.NewTCPTransport)
+
+	return []libp2p.Option{swarmOpts, tcpTransport}
 }
 
 func (t *Topology) makeid(d *DHT) string {


### PR DESCRIPTION
By only enabling the TCP transport we won't leak quic-reuse goroutines in our tests: https://github.com/libp2p/go-libp2p/issues/2514

Relates to: https://github.com/plprobelab/zikade/issues/34

We can't configure the leveldb timeout, so we're leaking one goroutine after each test for ~1s.

Then I found that there's another goroutine still dangling around after each test which could be closed with:

```go
import (
	log "github.com/ipfs/go-log/writer"
)

func ... {
   log.WriterGroup.Close()
}
```

