### PR TITLE
fix: avoid deadlocks in query and broadcast behaviours

### DIFF
--- a/internal/coord/brdcst_events.go
+++ b/internal/coord/brdcst_events.go
@@ -14,7 +14,7 @@ type EventStartBroadcast struct {
 	Message *pb.Message
 	Seed    []kadt.PeerID
 	Config  brdcst.Config
-	Notify  NotifyCloser[BehaviourEvent]
+	Notify  QueryMonitor[*EventBroadcastFinished]
 }
 
 func (*EventStartBroadcast) behaviourEvent() {}
@@ -31,4 +31,5 @@ type EventBroadcastFinished struct {
 	}
 }
 
-func (*EventBroadcastFinished) behaviourEvent() {}
+func (*EventBroadcastFinished) behaviourEvent()     {}
+func (*EventBroadcastFinished) terminalQueryEvent() {}

--- a/internal/coord/event.go
+++ b/internal/coord/event.go
@@ -50,6 +50,12 @@ type RoutingNotification interface {
 	routingNotification()
 }
 
+// TerminalQueryEvent is a type of [BehaviourEvent] that indicates a query has completed.
+type TerminalQueryEvent interface {
+	BehaviourEvent
+	terminalQueryEvent()
+}
+
 type EventStartBootstrap struct {
 	SeedNodes []kadt.PeerID
 }
@@ -84,7 +90,7 @@ type EventStartMessageQuery struct {
 	Target            kadt.Key
 	Message           *pb.Message
 	KnownClosestNodes []kadt.PeerID
-	Notify            NotifyCloser[BehaviourEvent]
+	Notify            QueryMonitor[*EventQueryFinished]
 	NumResults        int // the minimum number of nodes to successfully contact before considering iteration complete
 }
 
@@ -95,7 +101,7 @@ type EventStartFindCloserQuery struct {
 	QueryID           coordt.QueryID
 	Target            kadt.Key
 	KnownClosestNodes []kadt.PeerID
-	Notify            NotifyCloser[BehaviourEvent]
+	Notify            QueryMonitor[*EventQueryFinished]
 	NumResults        int // the minimum number of nodes to successfully contact before considering iteration complete
 }
 
@@ -186,7 +192,8 @@ type EventQueryFinished struct {
 	ClosestNodes []kadt.PeerID
 }
 
-func (*EventQueryFinished) behaviourEvent() {}
+func (*EventQueryFinished) behaviourEvent()     {}
+func (*EventQueryFinished) terminalQueryEvent() {}
 
 // EventRoutingUpdated is emitted by the coordinator when a new node has been verified and added to the routing table.
 type EventRoutingUpdated struct {

--- a/internal/coord/network.go
+++ b/internal/coord/network.go
@@ -106,17 +106,6 @@ func (b *NetworkBehaviour) Perform(ctx context.Context) (BehaviourEvent, bool) {
 	return nil, false
 }
 
-func (b *NetworkBehaviour) getNodeHandler(ctx context.Context, id kadt.PeerID) (*NodeHandler, error) {
-	b.nodeHandlersMu.Lock()
-	nh, ok := b.nodeHandlers[id]
-	if !ok {
-		nh = NewNodeHandler(id, b.rtr, b.logger, b.tracer)
-		b.nodeHandlers[id] = nh
-	}
-	b.nodeHandlersMu.Unlock()
-	return nh, nil
-}
-
 type NodeHandler struct {
 	self   kadt.PeerID
 	rtr    coordt.Router[kadt.Key, kadt.PeerID, *pb.Message]

--- a/internal/coord/query.go
+++ b/internal/coord/query.go
@@ -112,19 +112,28 @@ type PooledQueryBehaviour struct {
 	// cfg is a copy of the optional configuration supplied to the behaviour.
 	cfg PooledQueryConfig
 
+	// performMu is held while Perform is executing to ensure sequential execution of work.
+	performMu sync.Mutex
+
 	// pool is the query pool state machine used for managing individual queries.
+	// it must only be accessed while performMu is held
 	pool *query.Pool[kadt.Key, kadt.PeerID, *pb.Message]
 
 	// waiters is a map that keeps track of event notifications for each running query.
+	// it must only be accessed while performMu is held
 	waiters map[coordt.QueryID]NotifyCloser[BehaviourEvent]
 
-	// pendingMu guards access to pending
-	pendingMu sync.Mutex
+	// pendingOutbound is a queue of outbound events.
+	// it must only be accessed while performMu is held
+	pendingOutbound []BehaviourEvent
 
-	// pending is a queue of pending events that need to be processed.
-	pending []BehaviourEvent
+	// pendingInboundMu guards access to pendingInbound
+	pendingInboundMu sync.Mutex
 
-	// ready is a channel signaling that events are ready to be processed.
+	// pendingInbound is a queue of inbound events that are awaiting processing
+	pendingInbound []pendingEvent[BehaviourEvent]
+
+	// ready is a channel signaling that the behaviour has work to perform.
 	ready chan struct{}
 }
 
@@ -165,11 +174,88 @@ func (p *PooledQueryBehaviour) Notify(ctx context.Context, ev BehaviourEvent) {
 	ctx, span := p.cfg.Tracer.Start(ctx, "PooledQueryBehaviour.Notify")
 	defer span.End()
 
-	p.pendingMu.Lock()
-	defer p.pendingMu.Unlock()
+	p.pendingInboundMu.Lock()
+	defer p.pendingInboundMu.Unlock()
 
-	var cmd query.PoolEvent
-	switch ev := ev.(type) {
+	p.pendingInbound = append(p.pendingInbound, pendingEvent[BehaviourEvent]{Ctx: ctx, Event: ev})
+
+	select {
+	case p.ready <- struct{}{}:
+	default:
+	}
+}
+
+// Ready returns a channel that signals when the pooled query behaviour is ready to
+// perform work.
+func (p *PooledQueryBehaviour) Ready() <-chan struct{} {
+	return p.ready
+}
+
+// Perform executes the next available task from the queue of pending events or advances
+// the query pool. Returns an event containing the result of the work performed and a
+// true value, or nil and a false value if no event was generated.
+func (p *PooledQueryBehaviour) Perform(ctx context.Context) (BehaviourEvent, bool) {
+	p.performMu.Lock()
+	defer p.performMu.Unlock()
+
+	ctx, span := p.cfg.Tracer.Start(ctx, "PooledQueryBehaviour.Perform")
+	defer span.End()
+
+	defer p.updateReadyStatus()
+
+	// drain queued outbound events first.
+	ev, ok := p.nextPendingOutbound()
+	if ok {
+		return ev, true
+	}
+
+	// perform pending inbound work.
+	ev, ok = p.perfomNextInbound(ctx)
+	if ok {
+		return ev, true
+	}
+
+	// poll the query pool to trigger any timeouts and other scheduled work
+	ev, ok = p.advancePool(ctx, &query.EventPoolPoll{})
+	if ok {
+		return ev, true
+	}
+
+	// return any queued outbound work that may have been generated
+	return p.nextPendingOutbound()
+}
+
+func (p *PooledQueryBehaviour) nextPendingOutbound() (BehaviourEvent, bool) {
+	if len(p.pendingOutbound) == 0 {
+		return nil, false
+	}
+	var ev BehaviourEvent
+	ev, p.pendingOutbound = p.pendingOutbound[0], p.pendingOutbound[1:]
+	return ev, true
+}
+
+func (p *PooledQueryBehaviour) nextPendingInbound() (pendingEvent[BehaviourEvent], bool) {
+	p.pendingInboundMu.Lock()
+	defer p.pendingInboundMu.Unlock()
+	if len(p.pendingInbound) == 0 {
+		return pendingEvent[BehaviourEvent]{}, false
+	}
+	var pev pendingEvent[BehaviourEvent]
+	pev, p.pendingInbound = p.pendingInbound[0], p.pendingInbound[1:]
+	return pev, true
+}
+
+func (p *PooledQueryBehaviour) perfomNextInbound(ctx context.Context) (BehaviourEvent, bool) {
+	ctx, span := p.cfg.Tracer.Start(ctx, "PooledQueryBehaviour.perfomNextInbound")
+	defer span.End()
+	pev, ok := p.nextPendingInbound()
+	if !ok {
+		return nil, false
+	}
+
+	var cmd query.PoolEvent = &query.EventPoolPoll{}
+
+	switch ev := pev.Event.(type) {
 	case *EventStartFindCloserQuery:
 		cmd = &query.EventPoolAddFindCloserQuery[kadt.Key, kadt.PeerID]{
 			QueryID: ev.QueryID,
@@ -194,12 +280,7 @@ func (p *PooledQueryBehaviour) Notify(ctx context.Context, ev BehaviourEvent) {
 			QueryID: ev.QueryID,
 		}
 	case *EventGetCloserNodesSuccess:
-		for _, info := range ev.CloserNodes {
-			// TODO: do this after advancing pool
-			p.pending = append(p.pending, &EventAddNode{
-				NodeID: info,
-			})
-		}
+		p.queueAddNodeEvents(ev.CloserNodes)
 		waiter, ok := p.waiters[ev.QueryID]
 		if ok {
 			waiter.Notify(ctx, &EventQueryProgressed{
@@ -217,9 +298,7 @@ func (p *PooledQueryBehaviour) Notify(ctx context.Context, ev BehaviourEvent) {
 	case *EventGetCloserNodesFailure:
 		// queue an event that will notify the routing behaviour of a failed node
 		p.cfg.Logger.Debug("peer has no connectivity", tele.LogAttrPeerID(ev.To), "source", "query")
-		p.pending = append(p.pending, &EventNotifyNonConnectivity{
-			ev.To,
-		})
+		p.queueNonConnectivityEvent(ev.To)
 
 		cmd = &query.EventPoolNodeFailure[kadt.Key, kadt.PeerID]{
 			NodeID:  ev.To,
@@ -227,12 +306,7 @@ func (p *PooledQueryBehaviour) Notify(ctx context.Context, ev BehaviourEvent) {
 			Error:   ev.Err,
 		}
 	case *EventSendMessageSuccess:
-		for _, info := range ev.CloserNodes {
-			// TODO: do this after advancing pool
-			p.pending = append(p.pending, &EventAddNode{
-				NodeID: info,
-			})
-		}
+		p.queueAddNodeEvents(ev.CloserNodes)
 		waiter, ok := p.waiters[ev.QueryID]
 		if ok {
 			waiter.Notify(ctx, &EventQueryProgressed{
@@ -249,9 +323,7 @@ func (p *PooledQueryBehaviour) Notify(ctx context.Context, ev BehaviourEvent) {
 	case *EventSendMessageFailure:
 		// queue an event that will notify the routing behaviour of a failed node
 		p.cfg.Logger.Debug("peer has no connectivity", tele.LogAttrPeerID(ev.To), "source", "query")
-		p.pending = append(p.pending, &EventNotifyNonConnectivity{
-			ev.To,
-		})
+		p.queueNonConnectivityEvent(ev.To)
 
 		cmd = &query.EventPoolNodeFailure[kadt.Key, kadt.PeerID]{
 			NodeID:  ev.To,
@@ -263,59 +335,28 @@ func (p *PooledQueryBehaviour) Notify(ctx context.Context, ev BehaviourEvent) {
 	}
 
 	// attempt to advance the query pool
-	ev, ok := p.advancePool(ctx, cmd)
-	if ok {
-		p.pending = append(p.pending, ev)
-	}
-	if len(p.pending) > 0 {
+	return p.advancePool(pev.Ctx, cmd)
+}
+
+func (p *PooledQueryBehaviour) updateReadyStatus() {
+	if len(p.pendingOutbound) != 0 {
 		select {
 		case p.ready <- struct{}{}:
 		default:
 		}
+		return
 	}
-}
 
-// Ready returns a channel that signals when the pooled query behaviour is ready to
-// perform work.
-func (p *PooledQueryBehaviour) Ready() <-chan struct{} {
-	return p.ready
-}
+	p.pendingInboundMu.Lock()
+	hasPendingInbound := len(p.pendingInbound) != 0
+	p.pendingInboundMu.Unlock()
 
-// Perform executes the next available task from the queue of pending events or advances
-// the query pool. Returns the executed event and a boolean indicating whether work was
-// performed.
-func (p *PooledQueryBehaviour) Perform(ctx context.Context) (BehaviourEvent, bool) {
-	ctx, span := p.cfg.Tracer.Start(ctx, "PooledQueryBehaviour.Perform")
-	defer span.End()
-
-	// No inbound work can be done until Perform is complete
-	p.pendingMu.Lock()
-	defer p.pendingMu.Unlock()
-
-	for {
-		// drain queued events first.
-		if len(p.pending) > 0 {
-			var ev BehaviourEvent
-			ev, p.pending = p.pending[0], p.pending[1:]
-
-			if len(p.pending) > 0 {
-				select {
-				case p.ready <- struct{}{}:
-				default:
-				}
-			}
-			return ev, true
+	if hasPendingInbound {
+		select {
+		case p.ready <- struct{}{}:
+		default:
 		}
-
-		// attempt to advance the query pool
-		ev, ok := p.advancePool(ctx, &query.EventPoolPoll{})
-		if ok {
-			return ev, true
-		}
-
-		if len(p.pending) == 0 {
-			return nil, false
-		}
+		return
 	}
 }
 
@@ -368,4 +409,19 @@ func (p *PooledQueryBehaviour) advancePool(ctx context.Context, ev query.PoolEve
 	}
 
 	return nil, false
+}
+
+func (p *PooledQueryBehaviour) queueAddNodeEvents(nodes []kadt.PeerID) {
+	for _, info := range nodes {
+		// TODO: do this after advancing pool
+		p.pendingOutbound = append(p.pendingOutbound, &EventAddNode{
+			NodeID: info,
+		})
+	}
+}
+
+func (p *PooledQueryBehaviour) queueNonConnectivityEvent(nid kadt.PeerID) {
+	p.pendingOutbound = append(p.pendingOutbound, &EventNotifyNonConnectivity{
+		NodeID: nid,
+	})
 }

--- a/internal/coord/query_test.go
+++ b/internal/coord/query_test.go
@@ -1,9 +1,19 @@
 package coord
 
 import (
+	"context"
+	"sync"
 	"testing"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/plprobelab/zikade/internal/coord/coordt"
+	"github.com/plprobelab/zikade/internal/kadtest"
+	"github.com/plprobelab/zikade/internal/nettest"
+	"github.com/plprobelab/zikade/kadt"
+	"github.com/plprobelab/zikade/pb"
 )
 
 func TestPooledQueryConfigValidate(t *testing.T) {
@@ -67,4 +77,292 @@ func TestPooledQueryConfigValidate(t *testing.T) {
 		cfg.RequestTimeout = -1
 		require.Error(t, cfg.Validate())
 	})
+}
+
+func TestQueryBehaviourBase(t *testing.T) {
+	suite.Run(t, new(QueryBehaviourBaseTestSuite))
+}
+
+type QueryBehaviourBaseTestSuite struct {
+	suite.Suite
+
+	cfg   *PooledQueryConfig
+	top   *nettest.Topology
+	nodes []*nettest.Peer
+}
+
+func (ts *QueryBehaviourBaseTestSuite) SetupTest() {
+	clk := clock.NewMock()
+	top, nodes, err := nettest.LinearTopology(4, clk)
+	ts.Require().NoError(err)
+
+	ts.top = top
+	ts.nodes = nodes
+
+	ts.cfg = DefaultPooledQueryConfig()
+	ts.cfg.Clock = clk
+}
+
+func (ts *QueryBehaviourBaseTestSuite) TestNotifiesNoProgress() {
+	t := ts.T()
+	ctx := kadtest.CtxShort(t)
+
+	target := ts.nodes[3].NodeID.Key()
+	rt := ts.nodes[0].RoutingTable
+	seeds := rt.NearestNodes(target, 5)
+
+	b, err := NewPooledQueryBehaviour(ts.nodes[0].NodeID, ts.cfg)
+	ts.Require().NoError(err)
+
+	waiter := NewWaiter[BehaviourEvent]()
+	cmd := &EventStartFindCloserQuery{
+		QueryID:           "test",
+		Target:            target,
+		KnownClosestNodes: seeds,
+		Notify:            waiter,
+		NumResults:        10,
+	}
+
+	// queue the start of the query
+	b.Notify(ctx, cmd)
+
+	// behaviour should emit EventOutboundGetCloserNodes to start the query
+	bev, ok := b.Perform(ctx)
+	ts.Require().True(ok)
+	ts.Require().IsType(&EventOutboundGetCloserNodes{}, bev)
+
+	egc := bev.(*EventOutboundGetCloserNodes)
+	ts.Require().True(egc.To.Equal(ts.nodes[1].NodeID))
+
+	// notify failure
+	b.Notify(ctx, &EventGetCloserNodesFailure{
+		QueryID: "test",
+		To:      egc.To,
+		Target:  target,
+	})
+
+	// ensure that the waiter received query finished event
+	wev := kadtest.ReadItem[WaiterEvent[BehaviourEvent]](t, ctx, waiter.Chan())
+	ts.Require().IsType(&EventQueryFinished{}, wev.Event)
+}
+
+func (ts *QueryBehaviourBaseTestSuite) TestNotifiesQueryProgressed() {
+	t := ts.T()
+	ctx := kadtest.CtxShort(t)
+
+	target := ts.nodes[3].NodeID.Key()
+	rt := ts.nodes[0].RoutingTable
+	seeds := rt.NearestNodes(target, 5)
+
+	b, err := NewPooledQueryBehaviour(ts.nodes[0].NodeID, ts.cfg)
+	ts.Require().NoError(err)
+
+	waiter := NewWaiter[BehaviourEvent]()
+	cmd := &EventStartFindCloserQuery{
+		QueryID:           "test",
+		Target:            target,
+		KnownClosestNodes: seeds,
+		Notify:            waiter,
+		NumResults:        10,
+	}
+
+	// queue the start of the query
+	b.Notify(ctx, cmd)
+
+	// behaviour should emit EventOutboundGetCloserNodes to start the query
+	bev, ok := b.Perform(ctx)
+	ts.Require().True(ok)
+	ts.Require().IsType(&EventOutboundGetCloserNodes{}, bev)
+
+	egc := bev.(*EventOutboundGetCloserNodes)
+	ts.Require().True(egc.To.Equal(ts.nodes[1].NodeID))
+
+	// notify success
+	b.Notify(ctx, &EventGetCloserNodesSuccess{
+		QueryID:     "test",
+		To:          egc.To,
+		Target:      target,
+		CloserNodes: ts.nodes[1].RoutingTable.NearestNodes(target, 5),
+	})
+
+	// ensure that the waiter received query progressed event
+	wev := kadtest.ReadItem[WaiterEvent[BehaviourEvent]](t, ctx, waiter.Chan())
+	ts.Require().IsType(&EventQueryProgressed{}, wev.Event)
+}
+
+func (ts *QueryBehaviourBaseTestSuite) TestNotifiesQueryFinished() {
+	t := ts.T()
+	ctx := kadtest.CtxShort(t)
+
+	target := ts.nodes[3].NodeID.Key()
+	rt := ts.nodes[0].RoutingTable
+	seeds := rt.NearestNodes(target, 5)
+
+	b, err := NewPooledQueryBehaviour(ts.nodes[0].NodeID, ts.cfg)
+	ts.Require().NoError(err)
+
+	waiter := NewWaiter[BehaviourEvent]()
+	cmd := &EventStartFindCloserQuery{
+		QueryID:           "test",
+		Target:            target,
+		KnownClosestNodes: seeds,
+		Notify:            waiter,
+		NumResults:        10,
+	}
+
+	// queue the start of the query
+	b.Notify(ctx, cmd)
+
+	// behaviour should emit EventOutboundGetCloserNodes to start the query
+	bev, ok := b.Perform(ctx)
+	ts.Require().True(ok)
+	ts.Require().IsType(&EventOutboundGetCloserNodes{}, bev)
+
+	egc := bev.(*EventOutboundGetCloserNodes)
+	ts.Require().True(egc.To.Equal(ts.nodes[1].NodeID))
+
+	// notify success
+	b.Notify(ctx, &EventGetCloserNodesSuccess{
+		QueryID:     "test",
+		To:          egc.To,
+		Target:      target,
+		CloserNodes: ts.nodes[1].RoutingTable.NearestNodes(target, 5),
+	})
+
+	// ensure that the waiter received query progressed event
+	wev := kadtest.ReadItem[WaiterEvent[BehaviourEvent]](t, ctx, waiter.Chan())
+	ts.Require().IsType(&EventQueryProgressed{}, wev.Event)
+
+	// skip events until next EventOutboundGetCloserNodes is reached
+	for {
+		bev, ok = b.Perform(ctx)
+		ts.Require().True(ok)
+
+		egc, ok = bev.(*EventOutboundGetCloserNodes)
+		if ok {
+			break
+		}
+	}
+
+	ts.Require().True(egc.To.Equal(ts.nodes[2].NodeID))
+	// notify success but no further nodes
+	b.Notify(ctx, &EventGetCloserNodesSuccess{
+		QueryID: "test",
+		To:      egc.To,
+		Target:  target,
+	})
+
+	// ensure that the waiter received query progressed event
+	wev = kadtest.ReadItem[WaiterEvent[BehaviourEvent]](t, ctx, waiter.Chan())
+	ts.Require().IsType(&EventQueryProgressed{}, wev.Event)
+}
+
+func TestPooledQuery_deadlock_regression(t *testing.T) {
+	t.Skip()
+	ctx := kadtest.CtxShort(t)
+	msg := &pb.Message{}
+	queryID := coordt.QueryID("test")
+
+	_, nodes, err := nettest.LinearTopology(3, clock.New())
+	require.NoError(t, err)
+
+	// it would be better to just work with the queryBehaviour in this test.
+	// However, we want to test as many parts as possible and waitForQuery
+	// is defined on the coordinator. Therfore, we instantiate a coordinator
+	// and close it immediately to manually control state machine progression.
+	c, err := NewCoordinator(nodes[0].NodeID, nodes[0].Router, nodes[0].RoutingTable, nil)
+	require.NoError(t, err)
+	require.NoError(t, c.Close()) // close immediately so that we control the state machine progression
+
+	// define a function that produces success messages
+	successMsg := func(to kadt.PeerID, closer ...kadt.PeerID) *EventSendMessageSuccess {
+		return &EventSendMessageSuccess{
+			QueryID:     queryID,
+			Request:     msg,
+			To:          to,
+			Response:    nil,
+			CloserNodes: closer,
+		}
+	}
+
+	// start query
+	waiter := NewWaiter[BehaviourEvent]()
+	wrappedWaiter := NewNotifyCloserHook[BehaviourEvent](waiter)
+
+	waiterDone := make(chan struct{})
+	waiterMsg := make(chan struct{})
+	go func() {
+		defer close(waiterDone)
+		defer close(waiterMsg)
+		_, _, err = c.waitForQuery(ctx, queryID, waiter, func(ctx context.Context, id kadt.PeerID, resp *pb.Message, stats coordt.QueryStats) error {
+			waiterMsg <- struct{}{}
+			return coordt.ErrSkipRemaining
+		})
+	}()
+
+	// start the message query
+	c.queryBehaviour.Notify(ctx, &EventStartMessageQuery{
+		QueryID:           queryID,
+		Target:            msg.Target(),
+		Message:           msg,
+		KnownClosestNodes: []kadt.PeerID{nodes[1].NodeID},
+		Notify:            wrappedWaiter,
+		NumResults:        0,
+	})
+
+	// advance state machines and assert that the state machine
+	// wants to send an outbound message to another peer
+	ev, _ := c.queryBehaviour.Perform(ctx)
+	require.IsType(t, &EventOutboundSendMessage{}, ev)
+
+	// simulate a successful response from another node that returns one new node
+	// This should result in a message for the waiter
+	c.queryBehaviour.Notify(ctx, successMsg(nodes[1].NodeID, nodes[2].NodeID))
+
+	// Because we're blocking on the waiterMsg channel in the waitForQuery
+	// method above, we simulate a slow receiving waiter.
+
+	// Advance the query pool state machine. Because we returned a new node
+	// above, the query pool state machine wants to send another outbound query
+	ev, _ = c.queryBehaviour.Perform(ctx)
+	require.IsType(t, &EventAddNode{}, ev) // event to notify the routing table
+	ev, _ = c.queryBehaviour.Perform(ctx)
+	require.IsType(t, &EventOutboundSendMessage{}, ev)
+
+	hasLock := make(chan struct{})
+	var once sync.Once
+	wrappedWaiter.BeforeNotify = func(ctx context.Context, event BehaviourEvent) {
+		once.Do(func() {
+			require.IsType(t, &EventQueryProgressed{}, event) // verify test invariant
+			close(hasLock)
+		})
+	}
+
+	// Simulate a successful response from the new node. This node didn't return
+	// any new nodes to contact. This means the query pool behaviour will notify
+	// the waiter about a query progression and afterward about a finished
+	// query. Because (at the time of writing) the waiter has a channel buffer
+	// of 1, the channel cannot hold both events. At the same time, the waiter
+	// doesn't consume the messages because it's busy processing the previous
+	// query event (because we haven't released the blocking waiterMsg call above).
+	go c.queryBehaviour.Notify(ctx, successMsg(nodes[2].NodeID))
+
+	// wait until the above Notify call was handled by waiting until the hasLock
+	// channel was closed in the above BeforeNotify hook. If that hook is called
+	// we can be sure that the above Notify call has acquired the polled query
+	// behaviour's pendingMu lock.
+	kadtest.AssertClosed(t, ctx, hasLock)
+
+	// Since we know that the pooled query behaviour holds the lock we can
+	// release the slow waiter by reading an item from the waiterMsg channel.
+	kadtest.ReadItem(t, ctx, waiterMsg)
+
+	// At this point, the waitForQuery QueryFunc callback returned a
+	// coordt.ErrSkipRemaining. This instructs the waitForQuery method to notify
+	// the query behaviour with an EventStopQuery event. However, because the
+	// query behaviour is busy sending a message to the waiter it is holding the
+	// lock on the pending events to process. Therefore, this notify call will
+	// also block. At the same time, the waiter cannot read the new messages
+	// from the query behaviour because it tries to notify it.
+	kadtest.AssertClosed(t, ctx, waiterDone)
 }

--- a/internal/kadtest/chan.go
+++ b/internal/kadtest/chan.go
@@ -1,0 +1,36 @@
+package kadtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+)
+
+func ReadItem[T any](t testing.TB, ctx context.Context, c <-chan T) T {
+	t.Helper()
+
+	select {
+	case val, more := <-c:
+		require.True(t, more, "channel closed unexpectedly")
+		return val
+	case <-ctx.Done():
+		t.Fatal("timeout reading item")
+		return *new(T)
+	}
+}
+
+// AssertClosed triggers a test failure if the given channel was not closed but
+// carried more values or a timeout occurs (given by the context).
+func AssertClosed[T any](t testing.TB, ctx context.Context, c <-chan T) {
+	t.Helper()
+
+	select {
+	case _, more := <-c:
+		assert.False(t, more)
+	case <-ctx.Done():
+		t.Fatal("timeout closing channel")
+	}
+}


### PR DESCRIPTION
The query and broadcast behaviours notify query initiators of the ongoing progress of a query or broadcast. They also notify when the query or broadcast has finished. 

This set of changes fixes two types of deadlock:

1. slow consumer - originally the notification was sent on a channel with no defined behaviour for slow consumers of the channel. This could cause the query behaviour to block preventing any other query from progressing. This was particularly evident when a query completes since the last successful response was notified followed immediately by a finished notification to the same channel. This has been fixed by intruducing a `QueryMonitor` type that buffers progress events that cannot be notified. The `QueryMonitor` also uses a separate channel for notifying the completion of a query or broadcast and has better defined semantics for when notifications will be sent and when they will stop being sent.
2. reentrancy - originally the `Notify` and `Perform` methods of the behaviours were guarded by a single mutex since both could advance the state of the embedded state machine. However, notifying a query initiator could cause the intiator to call the `Notify` method to stop the query. Since the notification was made while the mutex was held this would deadlock on the call to `Notify`. This has been fixed by separating the locking behaviour between `Notify` and `Perform` and refactoring the logic to ensure that the state machines are advanced by `Perform` only. `Notify` now only queues the inbound event.