### PR TITLE
chore: refactor RoutingBehaviour

### DIFF
--- a/internal/coord/behaviour_test.go
+++ b/internal/coord/behaviour_test.go
@@ -2,11 +2,12 @@ package coord
 
 import (
 	"context"
+	"testing"
 )
 
 type RecordingSM[E any, S any] struct {
 	State    S
-	Received E
+	Received []E
 }
 
 func NewRecordingSM[E any, S any](response S) *RecordingSM[E, S] {
@@ -16,6 +17,27 @@ func NewRecordingSM[E any, S any](response S) *RecordingSM[E, S] {
 }
 
 func (r *RecordingSM[E, S]) Advance(ctx context.Context, e E) S {
-	r.Received = e
+	r.Received = append(r.Received, e)
 	return r.State
+}
+
+func (r *RecordingSM[E, S]) first() E {
+	if len(r.Received) == 0 {
+		var zero E
+		return zero
+	}
+	return r.Received[0]
+}
+
+func DrainBehaviour[I BehaviourEvent, O BehaviourEvent](t *testing.T, ctx context.Context, b Behaviour[I, O]) {
+	for {
+		select {
+		case <-b.Ready():
+			b.Perform(ctx)
+		case <-ctx.Done():
+			t.Fatal("context cancelled while draining behaviour")
+		default:
+			return
+		}
+	}
 }

--- a/internal/coord/routing.go
+++ b/internal/coord/routing.go
@@ -290,21 +290,36 @@ type RoutingBehaviour struct {
 	// cfg is a copy of the optional configuration supplied to the behaviour
 	cfg RoutingConfig
 
+	// performMu is held while Perform is executing to ensure sequential execution of work.
+	performMu sync.Mutex
+
 	// bootstrap is the bootstrap state machine, responsible for bootstrapping the routing table
+	// it must only be accessed while performMu is held
 	bootstrap coordt.StateMachine[routing.BootstrapEvent, routing.BootstrapState]
 
 	// include is the inclusion state machine, responsible for vetting nodes before including them in the routing table
+	// it must only be accessed while performMu is held
 	include coordt.StateMachine[routing.IncludeEvent, routing.IncludeState]
 
 	// probe is the node probing state machine, responsible for periodically checking connectivity of nodes in the routing table
+	// it must only be accessed while performMu is held
 	probe coordt.StateMachine[routing.ProbeEvent, routing.ProbeState]
 
 	// explore is the routing table explore state machine, responsible for increasing the occupanct of the routing table
+	// it must only be accessed while performMu is held
 	explore coordt.StateMachine[routing.ExploreEvent, routing.ExploreState]
 
-	pendingMu sync.Mutex
-	pending   []BehaviourEvent
-	ready     chan struct{}
+	// pendingOutbound is a queue of outbound events.
+	// it must only be accessed while performMu is held
+	pendingOutbound []BehaviourEvent
+
+	// pendingInboundMu guards access to pendingInbound
+	pendingInboundMu sync.Mutex
+
+	// pendingInbound is a queue of inbound events that are awaiting processing
+	pendingInbound []CtxEvent[BehaviourEvent]
+
+	ready chan struct{}
 }
 
 func NewRoutingBehaviour(self kadt.PeerID, rt routing.RoutingTableCpl[kadt.Key, kadt.PeerID], cfg *RoutingConfig) (*RoutingBehaviour, error) {
@@ -403,30 +418,112 @@ func ComposeRoutingBehaviour(
 }
 
 func (r *RoutingBehaviour) Notify(ctx context.Context, ev BehaviourEvent) {
+	r.pendingInboundMu.Lock()
+	defer r.pendingInboundMu.Unlock()
+
 	ctx, span := r.cfg.Tracer.Start(ctx, "RoutingBehaviour.Notify")
 	defer span.End()
 
-	r.pendingMu.Lock()
-	defer r.pendingMu.Unlock()
-	r.notify(ctx, ev)
+	r.pendingInbound = append(r.pendingInbound, CtxEvent[BehaviourEvent]{Ctx: ctx, Event: ev})
+
+	select {
+	case r.ready <- struct{}{}:
+	default:
+	}
 }
 
-// notify must only be called while r.pendingMu is held
-func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
-	ctx, span := r.cfg.Tracer.Start(ctx, "RoutingBehaviour.notify", trace.WithAttributes(attribute.String("event", fmt.Sprintf("%T", ev))))
+func (r *RoutingBehaviour) Ready() <-chan struct{} {
+	return r.ready
+}
+
+func (r *RoutingBehaviour) Perform(ctx context.Context) (BehaviourEvent, bool) {
+	r.performMu.Lock()
+	defer r.performMu.Unlock()
+
+	ctx, span := r.cfg.Tracer.Start(ctx, "RoutingBehaviour.Perform")
 	defer span.End()
 
-	switch ev := ev.(type) {
+	defer r.updateReadyStatus()
+
+	// drain queued events first.
+	// drain queued outbound events before starting new work.
+	ev, ok := r.nextPendingOutbound()
+	if ok {
+		return ev, true
+	}
+
+	// perform one piece of pending inbound work.
+	ev, ok = r.perfomNextInbound()
+	if ok {
+		return ev, true
+	}
+
+	// poll the child state machines in priority order to give each an opportunity to perform work
+	r.pollChildren(ctx)
+
+	// finally check if any pending events were accumulated in the meantime
+	return r.nextPendingOutbound()
+}
+
+func (r *RoutingBehaviour) nextPendingOutbound() (BehaviourEvent, bool) {
+	if len(r.pendingOutbound) == 0 {
+		return nil, false
+	}
+	var ev BehaviourEvent
+	ev, r.pendingOutbound = r.pendingOutbound[0], r.pendingOutbound[1:]
+	return ev, true
+}
+
+func (r *RoutingBehaviour) updateReadyStatus() {
+	if len(r.pendingOutbound) != 0 {
+		select {
+		case r.ready <- struct{}{}:
+		default:
+		}
+		return
+	}
+
+	r.pendingInboundMu.Lock()
+	hasPendingInbound := len(r.pendingInbound) != 0
+	r.pendingInboundMu.Unlock()
+
+	if hasPendingInbound {
+		select {
+		case r.ready <- struct{}{}:
+		default:
+		}
+		return
+	}
+}
+
+func (r *RoutingBehaviour) nextPendingInbound() (CtxEvent[BehaviourEvent], bool) {
+	r.pendingInboundMu.Lock()
+	defer r.pendingInboundMu.Unlock()
+	if len(r.pendingInbound) == 0 {
+		return CtxEvent[BehaviourEvent]{}, false
+	}
+	var pev CtxEvent[BehaviourEvent]
+	pev, r.pendingInbound = r.pendingInbound[0], r.pendingInbound[1:]
+	return pev, true
+}
+
+func (r *RoutingBehaviour) perfomNextInbound() (BehaviourEvent, bool) {
+	pev, ok := r.nextPendingInbound()
+	if !ok {
+		return nil, false
+	}
+
+	ctx, span := r.cfg.Tracer.Start(pev.Ctx, "PooledQueryBehaviour.perfomNextInbound")
+	defer span.End()
+
+	switch ev := pev.Event.(type) {
 	case *EventStartBootstrap:
 		span.SetAttributes(attribute.String("event", "EventStartBootstrap"))
 		cmd := &routing.EventBootstrapStart[kadt.Key, kadt.PeerID]{
 			KnownClosestNodes: ev.SeedNodes,
 		}
 		// attempt to advance the bootstrap
-		next, ok := r.advanceBootstrap(ctx, cmd)
-		if ok {
-			r.pending = append(r.pending, next)
-		}
+		return r.advanceBootstrap(ctx, cmd)
 
 	case *EventAddNode:
 		span.SetAttributes(attribute.String("event", "EventAddAddrInfo"))
@@ -434,14 +531,13 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 		if r.self.Equal(ev.NodeID) {
 			break
 		}
-		// TODO: apply ttl
 		cmd := &routing.EventIncludeAddCandidate[kadt.Key, kadt.PeerID]{
 			NodeID: ev.NodeID,
 		}
 		// attempt to advance the include
 		next, ok := r.advanceInclude(ctx, cmd)
 		if ok {
-			r.pending = append(r.pending, next)
+			r.pendingOutbound = append(r.pendingOutbound, next)
 		}
 
 	case *EventRoutingUpdated:
@@ -452,7 +548,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 		// attempt to advance the probe state machine
 		next, ok := r.advanceProbe(ctx, cmd)
 		if ok {
-			r.pending = append(r.pending, next)
+			r.pendingOutbound = append(r.pendingOutbound, next)
 		}
 
 	case *EventGetCloserNodesSuccess:
@@ -461,7 +557,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 		case routing.BootstrapQueryID:
 			for _, info := range ev.CloserNodes {
 				// TODO: do this after advancing bootstrap
-				r.pending = append(r.pending, &EventAddNode{
+				r.pendingOutbound = append(r.pendingOutbound, &EventAddNode{
 					NodeID: info,
 				})
 			}
@@ -472,7 +568,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 			// attempt to advance the bootstrap
 			next, ok := r.advanceBootstrap(ctx, cmd)
 			if ok {
-				r.pending = append(r.pending, next)
+				r.pendingOutbound = append(r.pendingOutbound, next)
 			}
 
 		case IncludeQueryID:
@@ -491,7 +587,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 			// attempt to advance the include
 			next, ok := r.advanceInclude(ctx, cmd)
 			if ok {
-				r.pending = append(r.pending, next)
+				r.pendingOutbound = append(r.pendingOutbound, next)
 			}
 
 		case ProbeQueryID:
@@ -510,12 +606,12 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 			// attempt to advance the probe state machine
 			next, ok := r.advanceProbe(ctx, cmd)
 			if ok {
-				r.pending = append(r.pending, next)
+				r.pendingOutbound = append(r.pendingOutbound, next)
 			}
 
 		case routing.ExploreQueryID:
 			for _, info := range ev.CloserNodes {
-				r.pending = append(r.pending, &EventAddNode{
+				r.pendingOutbound = append(r.pendingOutbound, &EventAddNode{
 					NodeID: info,
 				})
 			}
@@ -525,7 +621,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 			}
 			next, ok := r.advanceExplore(ctx, cmd)
 			if ok {
-				r.pending = append(r.pending, next)
+				r.pendingOutbound = append(r.pendingOutbound, next)
 			}
 
 		default:
@@ -543,7 +639,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 			// attempt to advance the bootstrap
 			next, ok := r.advanceBootstrap(ctx, cmd)
 			if ok {
-				r.pending = append(r.pending, next)
+				r.pendingOutbound = append(r.pendingOutbound, next)
 			}
 		case IncludeQueryID:
 			cmd := &routing.EventIncludeConnectivityCheckFailure[kadt.Key, kadt.PeerID]{
@@ -553,7 +649,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 			// attempt to advance the include state machine
 			next, ok := r.advanceInclude(ctx, cmd)
 			if ok {
-				r.pending = append(r.pending, next)
+				r.pendingOutbound = append(r.pendingOutbound, next)
 			}
 		case ProbeQueryID:
 			cmd := &routing.EventProbeConnectivityCheckFailure[kadt.Key, kadt.PeerID]{
@@ -563,7 +659,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 			// attempt to advance the probe state machine
 			next, ok := r.advanceProbe(ctx, cmd)
 			if ok {
-				r.pending = append(r.pending, next)
+				r.pendingOutbound = append(r.pendingOutbound, next)
 			}
 		case routing.ExploreQueryID:
 			cmd := &routing.EventExploreFindCloserFailure[kadt.Key, kadt.PeerID]{
@@ -573,7 +669,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 			// attempt to advance the explore
 			next, ok := r.advanceExplore(ctx, cmd)
 			if ok {
-				r.pending = append(r.pending, next)
+				r.pendingOutbound = append(r.pendingOutbound, next)
 			}
 
 		default:
@@ -593,7 +689,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 		}
 		next, ok := r.advanceInclude(ctx, cmd)
 		if ok {
-			r.pending = append(r.pending, next)
+			r.pendingOutbound = append(r.pendingOutbound, next)
 		}
 
 		// tell the probe state machine in case there is are connectivity checks that could satisfied
@@ -602,7 +698,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 		}
 		nextProbe, ok := r.advanceProbe(ctx, cmdProbe)
 		if ok {
-			r.pending = append(r.pending, nextProbe)
+			r.pendingOutbound = append(r.pendingOutbound, nextProbe)
 		}
 	case *EventNotifyNonConnectivity:
 		span.SetAttributes(attribute.String("event", "EventNotifyConnectivity"), attribute.String("nodeid", ev.NodeID.String()))
@@ -613,7 +709,7 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 		}
 		nextProbe, ok := r.advanceProbe(ctx, cmdProbe)
 		if ok {
-			r.pending = append(r.pending, nextProbe)
+			r.pendingOutbound = append(r.pendingOutbound, nextProbe)
 		}
 	case *EventRoutingPoll:
 		r.pollChildren(ctx)
@@ -622,71 +718,29 @@ func (r *RoutingBehaviour) notify(ctx context.Context, ev BehaviourEvent) {
 		panic(fmt.Sprintf("unexpected dht event: %T", ev))
 	}
 
-	if len(r.pending) > 0 {
-		select {
-		case r.ready <- struct{}{}:
-		default:
-		}
-	}
-}
-
-func (r *RoutingBehaviour) Ready() <-chan struct{} {
-	return r.ready
-}
-
-func (r *RoutingBehaviour) Perform(ctx context.Context) (BehaviourEvent, bool) {
-	ctx, span := r.cfg.Tracer.Start(ctx, "RoutingBehaviour.Perform")
-	defer span.End()
-
-	// No inbound work can be done until Perform is complete
-	r.pendingMu.Lock()
-	defer r.pendingMu.Unlock()
-
-	for {
-		// drain queued events first.
-		if len(r.pending) > 0 {
-			var ev BehaviourEvent
-			ev, r.pending = r.pending[0], r.pending[1:]
-
-			if len(r.pending) > 0 {
-				select {
-				case r.ready <- struct{}{}:
-				default:
-				}
-			}
-			return ev, true
-		}
-
-		// poll the child state machines in priority order to give each an opportunity to perform work
-		r.pollChildren(ctx)
-
-		// finally check if any pending events were accumulated in the meantime
-		if len(r.pending) == 0 {
-			return nil, false
-		}
-	}
+	return nil, false
 }
 
 // pollChildren must only be called while r.pendingMu is locked
 func (r *RoutingBehaviour) pollChildren(ctx context.Context) {
 	ev, ok := r.advanceBootstrap(ctx, &routing.EventBootstrapPoll{})
 	if ok {
-		r.pending = append(r.pending, ev)
+		r.pendingOutbound = append(r.pendingOutbound, ev)
 	}
 
 	ev, ok = r.advanceInclude(ctx, &routing.EventIncludePoll{})
 	if ok {
-		r.pending = append(r.pending, ev)
+		r.pendingOutbound = append(r.pendingOutbound, ev)
 	}
 
 	ev, ok = r.advanceProbe(ctx, &routing.EventProbePoll{})
 	if ok {
-		r.pending = append(r.pending, ev)
+		r.pendingOutbound = append(r.pendingOutbound, ev)
 	}
 
 	ev, ok = r.advanceExplore(ctx, &routing.EventExplorePoll{})
 	if ok {
-		r.pending = append(r.pending, ev)
+		r.pendingOutbound = append(r.pendingOutbound, ev)
 	}
 }
 
@@ -741,7 +795,7 @@ func (r *RoutingBehaviour) advanceInclude(ctx context.Context, ev routing.Includ
 		// a node has been included in the routing table
 
 		// notify other routing state machines that there is a new node in the routing table
-		r.notify(ctx, &EventRoutingUpdated{
+		r.Notify(ctx, &EventRoutingUpdated{
 			NodeID: st.NodeID,
 		})
 
@@ -785,14 +839,15 @@ func (r *RoutingBehaviour) advanceProbe(ctx context.Context, ev routing.ProbeEve
 
 		// emit an EventRoutingRemoved event to notify clients that the node has been removed
 		r.cfg.Logger.Debug("peer removed from routing table", tele.LogAttrPeerID(st.NodeID))
-		r.pending = append(r.pending, &EventRoutingRemoved{
+		r.pendingOutbound = append(r.pendingOutbound, &EventRoutingRemoved{
 			NodeID: st.NodeID,
 		})
 
 		// add the node to the inclusion list for a second chance
-		r.notify(ctx, &EventAddNode{
+		r.Notify(ctx, &EventAddNode{
 			NodeID: st.NodeID,
 		})
+
 	case *routing.StateProbeWaitingAtCapacity:
 		// the probe state machine is waiting for responses for checks and the maximum number of concurrent checks has been reached.
 		// nothing to do except wait for message response or timeout

--- a/internal/coord/routing_test.go
+++ b/internal/coord/routing_test.go
@@ -233,12 +233,13 @@ func TestRoutingStartBootstrapSendsEvent(t *testing.T) {
 	}
 
 	routingBehaviour.Notify(ctx, ev)
+	routingBehaviour.Perform(ctx)
 
 	// the event that should be passed to the bootstrap state machine
 	expected := &routing.EventBootstrapStart[kadt.Key, kadt.PeerID]{
 		KnownClosestNodes: ev.SeedNodes,
 	}
-	require.Equal(t, expected, bootstrap.Received)
+	require.Equal(t, expected, bootstrap.first())
 }
 
 func TestRoutingBootstrapGetClosestNodesSuccess(t *testing.T) {
@@ -266,11 +267,12 @@ func TestRoutingBootstrapGetClosestNodesSuccess(t *testing.T) {
 	}
 
 	routingBehaviour.Notify(ctx, ev)
+	routingBehaviour.Perform(ctx)
 
 	// bootstrap should receive message response event
-	require.IsType(t, &routing.EventBootstrapFindCloserResponse[kadt.Key, kadt.PeerID]{}, bootstrap.Received)
+	require.IsType(t, &routing.EventBootstrapFindCloserResponse[kadt.Key, kadt.PeerID]{}, bootstrap.first())
 
-	rev := bootstrap.Received.(*routing.EventBootstrapFindCloserResponse[kadt.Key, kadt.PeerID])
+	rev := bootstrap.first().(*routing.EventBootstrapFindCloserResponse[kadt.Key, kadt.PeerID])
 	require.True(t, nodes[1].NodeID.Equal(rev.NodeID))
 	require.Equal(t, ev.CloserNodes, rev.CloserNodes)
 }
@@ -301,11 +303,12 @@ func TestRoutingBootstrapGetClosestNodesFailure(t *testing.T) {
 	}
 
 	routingBehaviour.Notify(ctx, ev)
+	routingBehaviour.Perform(ctx)
 
 	// bootstrap should receive message response event
-	require.IsType(t, &routing.EventBootstrapFindCloserFailure[kadt.Key, kadt.PeerID]{}, bootstrap.Received)
+	require.IsType(t, &routing.EventBootstrapFindCloserFailure[kadt.Key, kadt.PeerID]{}, bootstrap.first())
 
-	rev := bootstrap.Received.(*routing.EventBootstrapFindCloserFailure[kadt.Key, kadt.PeerID])
+	rev := bootstrap.first().(*routing.EventBootstrapFindCloserFailure[kadt.Key, kadt.PeerID])
 	require.Equal(t, peer.ID(nodes[1].NodeID), peer.ID(rev.NodeID))
 	require.Equal(t, failure, rev.Error)
 }
@@ -332,12 +335,13 @@ func TestRoutingAddNodeInfoSendsEvent(t *testing.T) {
 	}
 
 	routingBehaviour.Notify(ctx, ev)
+	routingBehaviour.Perform(ctx)
 
 	// the event that should be passed to the include state machine
 	expected := &routing.EventIncludeAddCandidate[kadt.Key, kadt.PeerID]{
 		NodeID: ev.NodeID,
 	}
-	require.Equal(t, expected, include.Received)
+	require.Equal(t, expected, include.first())
 }
 
 func TestRoutingIncludeGetClosestNodesSuccess(t *testing.T) {
@@ -365,11 +369,12 @@ func TestRoutingIncludeGetClosestNodesSuccess(t *testing.T) {
 	}
 
 	routingBehaviour.Notify(ctx, ev)
+	routingBehaviour.Perform(ctx)
 
 	// include should receive message response event
-	require.IsType(t, &routing.EventIncludeConnectivityCheckSuccess[kadt.Key, kadt.PeerID]{}, include.Received)
+	require.IsType(t, &routing.EventIncludeConnectivityCheckSuccess[kadt.Key, kadt.PeerID]{}, include.first())
 
-	rev := include.Received.(*routing.EventIncludeConnectivityCheckSuccess[kadt.Key, kadt.PeerID])
+	rev := include.first().(*routing.EventIncludeConnectivityCheckSuccess[kadt.Key, kadt.PeerID])
 	require.Equal(t, peer.ID(nodes[1].NodeID), peer.ID(rev.NodeID))
 }
 
@@ -399,11 +404,12 @@ func TestRoutingIncludeGetClosestNodesFailure(t *testing.T) {
 	}
 
 	routingBehaviour.Notify(ctx, ev)
+	routingBehaviour.Perform(ctx)
 
 	// include should receive message response event
-	require.IsType(t, &routing.EventIncludeConnectivityCheckFailure[kadt.Key, kadt.PeerID]{}, include.Received)
+	require.IsType(t, &routing.EventIncludeConnectivityCheckFailure[kadt.Key, kadt.PeerID]{}, include.first())
 
-	rev := include.Received.(*routing.EventIncludeConnectivityCheckFailure[kadt.Key, kadt.PeerID])
+	rev := include.first().(*routing.EventIncludeConnectivityCheckFailure[kadt.Key, kadt.PeerID])
 	require.Equal(t, peer.ID(nodes[1].NodeID), peer.ID(rev.NodeID))
 	require.Equal(t, failure, rev.Error)
 }
@@ -465,20 +471,23 @@ func TestRoutingIncludedNodeAddToProbeList(t *testing.T) {
 		Target:      oev.Target,
 		CloserNodes: []kadt.PeerID{nodes[1].NodeID}, // must include one for include check to pass
 	})
+	dev, ok = routingBehaviour.Perform(ctx)
 
 	// the routing table should now contain the node
 	_, intable = rt.GetNode(candidate.Key())
 	require.True(t, intable)
 
 	// routing update event should be emitted from the include state machine
-	dev, ok = routingBehaviour.Perform(ctx)
 	require.True(t, ok)
 	require.IsType(t, &EventRoutingUpdated{}, dev)
+
+	// drain any pending work
+	DrainBehaviour[BehaviourEvent, BehaviourEvent](t, ctx, routingBehaviour)
 
 	// advance time past the probe check interval
 	clk.Add(probeCfg.CheckInterval)
 
-	// routing update event should be emitted from the include state machine
+	// probe should be sent for the node
 	dev, ok = routingBehaviour.Perform(ctx)
 	require.True(t, ok)
 	require.IsType(t, &EventOutboundGetCloserNodes{}, dev)
@@ -553,11 +562,12 @@ func TestRoutingExploreGetClosestNodesSuccess(t *testing.T) {
 		CloserNodes: []kadt.PeerID{nodes[2].NodeID},
 	}
 	routingBehaviour.Notify(ctx, ev)
+	routingBehaviour.Perform(ctx)
 
 	// explore should receive message response event
-	require.IsType(t, &routing.EventExploreFindCloserResponse[kadt.Key, kadt.PeerID]{}, explore.Received)
+	require.IsType(t, &routing.EventExploreFindCloserResponse[kadt.Key, kadt.PeerID]{}, explore.first())
 
-	rev := explore.Received.(*routing.EventExploreFindCloserResponse[kadt.Key, kadt.PeerID])
+	rev := explore.first().(*routing.EventExploreFindCloserResponse[kadt.Key, kadt.PeerID])
 	require.True(t, nodes[1].NodeID.Equal(rev.NodeID))
 	require.Equal(t, ev.CloserNodes, rev.CloserNodes)
 }
@@ -588,11 +598,12 @@ func TestRoutingExploreGetClosestNodesFailure(t *testing.T) {
 	}
 
 	routingBehaviour.Notify(ctx, ev)
+	routingBehaviour.Perform(ctx)
 
 	// bootstrap should receive message response event
-	require.IsType(t, &routing.EventExploreFindCloserFailure[kadt.Key, kadt.PeerID]{}, explore.Received)
+	require.IsType(t, &routing.EventExploreFindCloserFailure[kadt.Key, kadt.PeerID]{}, explore.first())
 
-	rev := explore.Received.(*routing.EventExploreFindCloserFailure[kadt.Key, kadt.PeerID])
+	rev := explore.first().(*routing.EventExploreFindCloserFailure[kadt.Key, kadt.PeerID])
 	require.Equal(t, peer.ID(nodes[1].NodeID), peer.ID(rev.NodeID))
 	require.Equal(t, failure, rev.Error)
 }


### PR DESCRIPTION
Refactor RoutingBehaviour to the new pattern adopted for QueryBehaviour and BrdcstBehaviour. Notify now queues the event and signals that the behaviour is ready. Perform is responsible for acting on any incoming or generated event.