### PR TITLE
chore: rename PooledQueryBehaviour to QueryBehaviour

### DIFF
--- a/internal/coord/coordinator.go
+++ b/internal/coord/coordinator.go
@@ -93,7 +93,7 @@ type CoordinatorConfig struct {
 	Routing RoutingConfig
 
 	// Query is the configuration used for the [PooledQueryBehaviour] which manages the execution of user queries.
-	Query PooledQueryConfig
+	Query QueryConfig
 }
 
 // Validate checks the configuration options and returns an error if any have invalid values.
@@ -138,7 +138,7 @@ func DefaultCoordinatorConfig() *CoordinatorConfig {
 		TracerProvider: otel.GetTracerProvider(),
 	}
 
-	cfg.Query = *DefaultPooledQueryConfig()
+	cfg.Query = *DefaultQueryConfig()
 	cfg.Query.Clock = cfg.Clock
 	cfg.Query.Logger = cfg.Logger.With("behaviour", "pooledquery")
 	cfg.Query.Tracer = cfg.TracerProvider.Tracer(tele.TracerName)
@@ -165,7 +165,7 @@ func NewCoordinator(self kadt.PeerID, rtr coordt.Router[kadt.Key, kadt.PeerID, *
 		return nil, fmt.Errorf("init telemetry: %w", err)
 	}
 
-	queryBehaviour, err := NewPooledQueryBehaviour(self, &cfg.Query)
+	queryBehaviour, err := NewQueryBehaviour(self, &cfg.Query)
 	if err != nil {
 		return nil, fmt.Errorf("query behaviour: %w", err)
 	}

--- a/internal/coord/query_test.go
+++ b/internal/coord/query_test.go
@@ -16,34 +16,34 @@ import (
 	"github.com/plprobelab/zikade/pb"
 )
 
-func TestPooledQueryConfigValidate(t *testing.T) {
+func TestQueryConfigValidate(t *testing.T) {
 	t.Run("default is valid", func(t *testing.T) {
-		cfg := DefaultPooledQueryConfig()
+		cfg := DefaultQueryConfig()
 
 		require.NoError(t, cfg.Validate())
 	})
 
 	t.Run("clock is not nil", func(t *testing.T) {
-		cfg := DefaultPooledQueryConfig()
+		cfg := DefaultQueryConfig()
 
 		cfg.Clock = nil
 		require.Error(t, cfg.Validate())
 	})
 
 	t.Run("logger not nil", func(t *testing.T) {
-		cfg := DefaultPooledQueryConfig()
+		cfg := DefaultQueryConfig()
 		cfg.Logger = nil
 		require.Error(t, cfg.Validate())
 	})
 
 	t.Run("tracer not nil", func(t *testing.T) {
-		cfg := DefaultPooledQueryConfig()
+		cfg := DefaultQueryConfig()
 		cfg.Tracer = nil
 		require.Error(t, cfg.Validate())
 	})
 
 	t.Run("query concurrency positive", func(t *testing.T) {
-		cfg := DefaultPooledQueryConfig()
+		cfg := DefaultQueryConfig()
 
 		cfg.Concurrency = 0
 		require.Error(t, cfg.Validate())
@@ -52,7 +52,7 @@ func TestPooledQueryConfigValidate(t *testing.T) {
 	})
 
 	t.Run("query timeout positive", func(t *testing.T) {
-		cfg := DefaultPooledQueryConfig()
+		cfg := DefaultQueryConfig()
 
 		cfg.Timeout = 0
 		require.Error(t, cfg.Validate())
@@ -61,7 +61,7 @@ func TestPooledQueryConfigValidate(t *testing.T) {
 	})
 
 	t.Run("request concurrency positive", func(t *testing.T) {
-		cfg := DefaultPooledQueryConfig()
+		cfg := DefaultQueryConfig()
 
 		cfg.RequestConcurrency = 0
 		require.Error(t, cfg.Validate())
@@ -70,7 +70,7 @@ func TestPooledQueryConfigValidate(t *testing.T) {
 	})
 
 	t.Run("request timeout positive", func(t *testing.T) {
-		cfg := DefaultPooledQueryConfig()
+		cfg := DefaultQueryConfig()
 
 		cfg.RequestTimeout = 0
 		require.Error(t, cfg.Validate())
@@ -86,7 +86,7 @@ func TestQueryBehaviourBase(t *testing.T) {
 type QueryBehaviourBaseTestSuite struct {
 	suite.Suite
 
-	cfg   *PooledQueryConfig
+	cfg   *QueryConfig
 	top   *nettest.Topology
 	nodes []*nettest.Peer
 }
@@ -99,7 +99,7 @@ func (ts *QueryBehaviourBaseTestSuite) SetupTest() {
 	ts.top = top
 	ts.nodes = nodes
 
-	ts.cfg = DefaultPooledQueryConfig()
+	ts.cfg = DefaultQueryConfig()
 	ts.cfg.Clock = clk
 }
 
@@ -111,7 +111,7 @@ func (ts *QueryBehaviourBaseTestSuite) TestNotifiesNoProgress() {
 	rt := ts.nodes[0].RoutingTable
 	seeds := rt.NearestNodes(target, 5)
 
-	b, err := NewPooledQueryBehaviour(ts.nodes[0].NodeID, ts.cfg)
+	b, err := NewQueryBehaviour(ts.nodes[0].NodeID, ts.cfg)
 	ts.Require().NoError(err)
 
 	waiter := NewQueryWaiter(5)
@@ -158,7 +158,7 @@ func (ts *QueryBehaviourBaseTestSuite) TestNotifiesQueryProgressed() {
 	rt := ts.nodes[0].RoutingTable
 	seeds := rt.NearestNodes(target, 5)
 
-	b, err := NewPooledQueryBehaviour(ts.nodes[0].NodeID, ts.cfg)
+	b, err := NewQueryBehaviour(ts.nodes[0].NodeID, ts.cfg)
 	ts.Require().NoError(err)
 
 	waiter := NewQueryWaiter(5)
@@ -206,7 +206,7 @@ func (ts *QueryBehaviourBaseTestSuite) TestNotifiesQueryFinished() {
 	rt := ts.nodes[0].RoutingTable
 	seeds := rt.NearestNodes(target, 5)
 
-	b, err := NewPooledQueryBehaviour(ts.nodes[0].NodeID, ts.cfg)
+	b, err := NewQueryBehaviour(ts.nodes[0].NodeID, ts.cfg)
 	ts.Require().NoError(err)
 
 	waiter := NewQueryWaiter(5)
@@ -274,7 +274,7 @@ func (ts *QueryBehaviourBaseTestSuite) TestNotifiesQueryFinished() {
 	kadtest.ReadItem[CtxEvent[*EventQueryFinished]](t, ctx, waiter.Finished())
 }
 
-func TestPooledQuery_deadlock_regression(t *testing.T) {
+func TestQuery_deadlock_regression(t *testing.T) {
 	t.Skip()
 	ctx := kadtest.CtxShort(t)
 	msg := &pb.Message{}


### PR DESCRIPTION
Just simplifies this name a bit since we don't currently have a non-pooled query behaviour